### PR TITLE
Render inner HTML passed as the "dangerouslySetInnerHTML" object in the preview

### DIFF
--- a/src/client/components/__tests__/__snapshots__/120-preview.test.js.snap
+++ b/src/client/components/__tests__/__snapshots__/120-preview.test.js.snap
@@ -44,7 +44,7 @@ exports[`Preview renders correctly with HTML snapshot 1`] = `
   <style>
     body { color: green }
   </style>
-  <div></div>
+  <div><div>Snapshot contents</div></div>
 </div>
 `;
 

--- a/src/serializer/index.js
+++ b/src/serializer/index.js
@@ -130,6 +130,12 @@ function printInstance(instance, print, indent, opts) {
     indent2 = str => str;
   }
 
+  const dangerousInnerHTML = instance.props && instance.props.dangerouslySetInnerHTML;
+  if (dangerousInnerHTML) {
+    result += `${dangerousInnerHTML.__html}</${instance.type}>`;
+    return result;
+  }
+
   const children = instance.children;
   if (children) {
     const printedChildren = printChildren(children, print, indent2, opts2);


### PR DESCRIPTION
This commit adds support for rendering "dangerous" HTML into the preview.
It also updates related test that didn't expect this content to be rendered.